### PR TITLE
Fixes slicing with negative value error message - llvm_codegen_expr.c

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -42,6 +42,7 @@
 - Fix for bug when `@format` encountered `*` in some cases.
 - Compiler segfault on global slice initialization with null[:0] #2404.
 - Use correct allocator in `replace`.
+- Fix incorrect panic message when slicing with negative size.
 
 ### Stdlib changes
 - Add `==` to `Pair`, `Triple` and TzDateTime. Add print to `Pair` and `Triple`.

--- a/src/compiler/llvm_codegen_expr.c
+++ b/src/compiler/llvm_codegen_expr.c
@@ -2791,6 +2791,7 @@ static void llvm_emit_slice_values(GenContext *c, Expr *slice, BEValue *parent_r
 				llvm_emit_int_comp(c, &excess, &start_index, &end_index, BINARYOP_GT);
 				BEValue actual_end_len = end_index;
 				actual_end_len.value = llvm_emit_sub_int(c, end_index.type, end_index.value, start_index.value, slice->span);
+				actual_end_len.type = type_isz;
 				llvm_emit_panic_if_true(c, &excess, "Negative slice length", slice->span, "Negative value (%d) given for slice length.", &actual_end_len, NULL);
 				if (len.value)
 				{


### PR DESCRIPTION
Fixes printing negative value

Example:
```
fn void main()
{
    int[100] arr;
    usz a = 35;
    usz b = 36;
    arr[b:a - b];
}
```

output should be:
ERROR: 'Negative value (-1) given for slice length.'